### PR TITLE
Update Dockerfile. Add build ARG to avoid ('pread64' undeclared ) error

### DIFF
--- a/server/go-kgp/Dockerfile
+++ b/server/go-kgp/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache sqlite graphviz gcc libc-dev
 ADD . /app/
 WORKDIR /app/
 RUN go mod download
+ARG CGO_CFLAGS="-D_LARGEFILE64_SOURCE"
 RUN go build -v -o /go-kgp ./cmd/practice
 
 # Mount an external volume and use it as a working directory


### PR DESCRIPTION
I was building a docker image on my Windows machine and I got the following error
```sqlite3-binding.c:35911:42: error: 'pread64' undeclared here (not in a function); did you mean 'pread'?```

I searched a bit and applied suggestion (suggested [here](https://github.com/mattn/go-sqlite3/issues/1164)

After the change, I successfully built my Docker image on my Windows machine. The suggested change will also work for Linux machines.